### PR TITLE
Bump minor version to 0.7.0 (#66)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v6
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
@@ -35,7 +35,7 @@ jobs:
         make run-ci
 
     - name: Create coverage badge
-      uses: gaelgirodon/ci-badges-action@v1.8.0
+      uses: gaelgirodon/ci-badges-action@v1.9.0
       with:
         gist-id: ${{ vars.GIST_ID_BADGES }}
         token: ${{ secrets.GIST_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         shell: bash
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
 
       - name: Build and publish
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,10 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "python-telegram-bot==22.0",
-    "pydantic==2.11.1",
+    "python-telegram-bot==22.2",
+    "pydantic==2.11.7",
     "loguru==0.7.3",
-    "playwright==1.51.0",
+    "playwright==1.53.0",
 ]
 dynamic = ["version"]
 

--- a/src/web_watchr/__init__.py
+++ b/src/web_watchr/__init__.py
@@ -3,6 +3,6 @@ from loguru import logger
 from .watchr import Watchr
 
 __all__ = ["Watchr"]
-__version__ = "0.6.0"
+__version__ = "0.7.0"
 
 logger.disable("website_monitoring_bot")


### PR DESCRIPTION
* chore(deps): Bump gaelgirodon/ci-badges-action from 1.6.0 to 1.7.0 (#35)

* chore(deps): Bump gaelgirodon/ci-badges-action from 1.6.0 to 1.7.0

Bumps [gaelgirodon/ci-badges-action](https://github.com/gaelgirodon/ci-badges-action) from 1.6.0 to 1.7.0.
- [Release notes](https://github.com/gaelgirodon/ci-badges-action/releases)
- [Changelog](https://github.com/GaelGirodon/ci-badges-action/blob/main/CHANGELOG.md)
- [Commits](https://github.com/gaelgirodon/ci-badges-action/compare/v1.6.0...1.7.0)

---
updated-dependencies:
- dependency-name: gaelgirodon/ci-badges-action dependency-type: direct:production update-type: version-update:semver-minor ...



* Fix version prefix

---------





* chore(pyproject.toml): Bump loguru from 0.7.2 to 0.7.3 (#38)

Bumps [loguru](https://github.com/Delgan/loguru) from 0.7.2 to 0.7.3.
- [Release notes](https://github.com/Delgan/loguru/releases)
- [Changelog](https://github.com/Delgan/loguru/blob/master/CHANGELOG.rst)
- [Commits](https://github.com/Delgan/loguru/compare/0.7.2...0.7.3)

---
updated-dependencies:
- dependency-name: loguru dependency-type: direct:production update-type: version-update:semver-patch ...




* chore(pyproject.toml): Bump python-telegram-bot from 21.7 to 21.9 (#40)

Bumps [python-telegram-bot](https://github.com/python-telegram-bot/python-telegram-bot) from 21.7 to 21.9.
- [Release notes](https://github.com/python-telegram-bot/python-telegram-bot/releases)
- [Changelog](https://github.com/python-telegram-bot/python-telegram-bot/blob/master/CHANGES.rst)
- [Commits](https://github.com/python-telegram-bot/python-telegram-bot/compare/v21.7...v21.9)

---
updated-dependencies:
- dependency-name: python-telegram-bot dependency-type: direct:production update-type: version-update:semver-minor ...




* chore(pyproject.toml): Bump playwright from 1.49.0 to 1.49.1 (#41)

Bumps [playwright](https://github.com/microsoft/playwright-python) from 1.49.0 to 1.49.1.
- [Release notes](https://github.com/microsoft/playwright-python/releases)
- [Commits](https://github.com/microsoft/playwright-python/compare/v1.49.0...v1.49.1)

---
updated-dependencies:
- dependency-name: playwright dependency-type: direct:production update-type: version-update:semver-patch ...




* chore(pyproject.toml): Bump pydantic from 2.10.1 to 2.10.4 (#42)

Bumps [pydantic](https://github.com/pydantic/pydantic) from 2.10.1 to 2.10.4.
- [Release notes](https://github.com/pydantic/pydantic/releases)
- [Changelog](https://github.com/pydantic/pydantic/blob/main/HISTORY.md)
- [Commits](https://github.com/pydantic/pydantic/compare/v2.10.1...v2.10.4)

---
updated-dependencies:
- dependency-name: pydantic dependency-type: direct:production update-type: version-update:semver-patch ...




* chore(deps): Bump astral-sh/setup-uv from 4 to 5

Bumps [astral-sh/setup-uv](https://github.com/astral-sh/setup-uv) from 4 to 5.
- [Release notes](https://github.com/astral-sh/setup-uv/releases)
- [Commits](https://github.com/astral-sh/setup-uv/compare/v4...v5)

---
updated-dependencies:
- dependency-name: astral-sh/setup-uv dependency-type: direct:production update-type: version-update:semver-major ...



* chore(pyproject.toml): Bump python-telegram-bot from 21.9 to 21.10 (#44)

* chore(pyproject.toml): Bump pydantic from 2.10.4 to 2.10.5 (#45)

* chore(pyproject.toml): Bump pydantic from 2.10.5 to 2.10.6 (#46)

* Correct URI for coverage badges

* chore(pyproject.toml): Bump playwright from 1.49.1 to 1.50.0 (#48)

* chore(pyproject.toml): Bump python-telegram-bot from 21.10 to 22.0

Bumps [python-telegram-bot](https://github.com/python-telegram-bot/python-telegram-bot) from 21.10 to 22.0.
- [Release notes](https://github.com/python-telegram-bot/python-telegram-bot/releases)
- [Commits](https://github.com/python-telegram-bot/python-telegram-bot/compare/v21.10...v22.0)

---
updated-dependencies:
- dependency-name: python-telegram-bot dependency-type: direct:production update-type: version-update:semver-major ...



* chore(pyproject.toml): Bump playwright from 1.50.0 to 1.51.0

Bumps [playwright](https://github.com/microsoft/playwright-python) from 1.50.0 to 1.51.0.
- [Release notes](https://github.com/microsoft/playwright-python/releases)
- [Commits](https://github.com/microsoft/playwright-python/compare/v1.50.0...v1.51.0)

---
updated-dependencies:
- dependency-name: playwright dependency-type: direct:production update-type: version-update:semver-minor ...



* chore(pyproject.toml): Bump pydantic from 2.10.6 to 2.11.1

Bumps [pydantic](https://github.com/pydantic/pydantic) from 2.10.6 to 2.11.1.
- [Release notes](https://github.com/pydantic/pydantic/releases)
- [Changelog](https://github.com/pydantic/pydantic/blob/main/HISTORY.md)
- [Commits](https://github.com/pydantic/pydantic/compare/v2.10.6...v2.11.1)

---
updated-dependencies:
- dependency-name: pydantic dependency-type: direct:production update-type: version-update:semver-minor ...



* chore(deps): Bump gaelgirodon/ci-badges-action from 1.7.0 to 1.8.0

Bumps [gaelgirodon/ci-badges-action](https://github.com/gaelgirodon/ci-badges-action) from 1.7.0 to 1.8.0.
- [Release notes](https://github.com/gaelgirodon/ci-badges-action/releases)
- [Changelog](https://github.com/GaelGirodon/ci-badges-action/blob/main/CHANGELOG.md)
- [Commits](https://github.com/gaelgirodon/ci-badges-action/compare/v1.7.0...1.8.0)

---
updated-dependencies:
- dependency-name: gaelgirodon/ci-badges-action dependency-type: direct:production update-type: version-update:semver-minor ...



* Update ci.yml

* Version bump to v0.6.0

* chore(pyproject.toml): Bump pydantic from 2.11.1 to 2.11.2

Bumps [pydantic](https://github.com/pydantic/pydantic) from 2.11.1 to 2.11.2.
- [Release notes](https://github.com/pydantic/pydantic/releases)
- [Changelog](https://github.com/pydantic/pydantic/blob/main/HISTORY.md)
- [Commits](https://github.com/pydantic/pydantic/compare/v2.11.1...v2.11.2)

---
updated-dependencies:
- dependency-name: pydantic dependency-version: 2.11.2 dependency-type: direct:production update-type: version-update:semver-patch ...



* chore(deps): Bump gaelgirodon/ci-badges-action from 1.8.0 to 1.9.0 (#56)

* chore(deps): Bump gaelgirodon/ci-badges-action from 1.8.0 to 1.9.0

Bumps [gaelgirodon/ci-badges-action](https://github.com/gaelgirodon/ci-badges-action) from 1.8.0 to 1.9.0.
- [Release notes](https://github.com/gaelgirodon/ci-badges-action/releases)
- [Changelog](https://github.com/GaelGirodon/ci-badges-action/blob/main/CHANGELOG.md)
- [Commits](https://github.com/gaelgirodon/ci-badges-action/compare/v1.8.0...1.9.0)

---
updated-dependencies:
- dependency-name: gaelgirodon/ci-badges-action dependency-version: 1.9.0 dependency-type: direct:production update-type: version-update:semver-minor ...



* Update ci.yml

---------





* chore(deps): Bump astral-sh/setup-uv from 5 to 6 (#58)

* chore(pyproject.toml): Bump pydantic from 2.11.2 to 2.11.7 (#63)

* chore(pyproject.toml): Bump python-telegram-bot from 22.0 to 22.2 (#64)

* chore(pyproject.toml): Bump playwright from 1.51.0 to 1.53.0 (#65)

* Bump minor version

---------